### PR TITLE
google-github-actions/setup-gcloud

### DIFF
--- a/actions.yml
+++ b/actions.yml
@@ -347,6 +347,10 @@ golang/govulncheck-action:
   '*':
     expires_at: 2025-08-01
     keep: true
+google-github-actions/setup-gcloud:
+  77e7a554d41e2ee56fc945c52dfd3f33d12def9a:
+    expires_at: 2050-01-01
+    keep: true
 gr2m/twitter-together:
   '*':
     expires_at: 2025-08-01


### PR DESCRIPTION
# Request for adding a new GitHub Action to the allow list

## Overview

Configures the [Google Cloud SDK](https://cloud.google.com/sdk/) in the GitHub Actions environment. The Google Cloud SDK includes both the [gcloud](https://cloud.google.com/sdk/gcloud/) and [gsutil](https://cloud.google.com/storage/docs/gsutil) binaries.

Used to deploy Grails Forge to Google Cloud

https://github.com/apache/grails-forge/blob/0f1edad6babf1aa0c07226a874fc3a9281ae9045/.github/workflows/release-gcp-deploy.yml#L43

**Name of action:** google-github-actions/setup-gcloud

**URL of action:** 
https://github.com/marketplace/actions/set-up-gcloud-cloud-sdk-environment
https://github.com/google-github-actions/setup-gcloud

**Version to pin to ([hash only](https://infra.apache.org/github-actions-policy.html)):**
77e7a554d41e2ee56fc945c52dfd3f33d12def9a (v2.1.4)

## Permissions

none

## Related Actions

None of the `google-github-actions` actions are currently listed

## Checklist
You should be able to check most of these boxes for an action to be considered for review.
Please check all boxes that currently apply:

- [x] The action is listed in the GitHub Actions Marketplace
- [x] The action is not already on the list of approved actions
- [x] The action has a sufficient number of contributors or has contributors within the ASF community
- [x] The action has a clearly defined license
- [x] The action is actively developed or maintained
- [x] The action has CI/unit tests configured
